### PR TITLE
fix: remove error modal when no payments found for address

### DIFF
--- a/src/app/tables/voterstatistics/voterstatistics.component.ts
+++ b/src/app/tables/voterstatistics/voterstatistics.component.ts
@@ -90,7 +90,8 @@ export class VoterstatisticsComponent implements OnInit {
         );
 
   	  }, (error) => {
-  	    Swal.fire("Error","An error has occured.<br/>Get public address payment information failed.","error");
+          console.log("Unable to get public address payment information.");
+  	    //Swal.fire("Error","An error has occured.<br/>Get public address payment information failed.","error");
   	  }
 	  );
 	}


### PR DESCRIPTION
Remove the error modal when no payments found for address in voters statistics

# Description
When an address has pending balance but still no payment executed the frontend returns an error modal every time we access the statistics page which is a bit annoying, this pull just remove that modal.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
